### PR TITLE
Issue/fix stored procedure out parameter 

### DIFF
--- a/src/Database/Log/MethodLoggingStatement.php
+++ b/src/Database/Log/MethodLoggingStatement.php
@@ -121,11 +121,15 @@ class MethodLoggingStatement extends MethodStatementDecorator
      * @param string|int $column Name or param position to be bound
      * @param mixed $value The value to bind to variable in query
      * @param string|int|null $type PDO type or name of configured Type class
+     * @param int $length [optional]
+     * Length of the data type. To indicate that a parameter is an OUT
+     * parameter from a stored procedure, you must explicitly set the
+     * length.
      * @return void
      */
-    public function bindParam($column, &$value, $type = 'string')
+    public function bindParam($column, &$value, $type = 'string', $length = null)
     {
-        parent::bindParam($column, $value, $type);
+        parent::bindParam($column, $value, $type, $length);
         if ($type === null) {
             $type = 'string';
         }

--- a/src/Database/Schema/Method.php
+++ b/src/Database/Schema/Method.php
@@ -56,17 +56,30 @@ class Method
     protected $_typeMap = [];
 
     /**
-     * The valid keys that can be used in a column
+     * The valid keys that can be used in a IN column
      * definition.
      *
      * @var array
      */
-    protected static $_columnParameters = [
+    protected static $_columnInParameters = [
         'type' => null,
         'in' => null,
         'out' => null,
     ];
 
+    /**
+     * The valid keys that can be used in a OUT column
+     * definition.
+     *
+     * @var array
+     */
+    protected static $_columnOutParameters = [
+        'type' => null,
+        'in' => null,
+        'out' => null,
+        'length' => null,
+    ];
+    
     /**
      * Additional type specific properties.
      *
@@ -121,7 +134,11 @@ class Method
         if (is_string($attrs)) {
             $attrs = ['type' => $attrs];
         }
-        $valid = static::$_columnParameters;
+        if ($attrs['out']) {
+            $valid = static::$_columnOutParameters;
+        } else {
+            $valid = static::$_columnInParameters;
+        }
         if (isset(static::$_columnExtras[$attrs['type']])) {
             $valid += static::$_columnExtras[$attrs['type']];
         }

--- a/src/Database/Statement/Method/MethodPDOStatement.php
+++ b/src/Database/Statement/Method/MethodPDOStatement.php
@@ -60,9 +60,13 @@ class MethodPDOStatement extends MethodStatementDecorator
      * @param string|int $column name or param position to be bound
      * @param mixed $value The value to bind to variable in query
      * @param string|int $type OCI type or name of configured Type class
+     * @param int $length [optional]
+     * Length of the data type. To indicate that a parameter is an OUT
+     * parameter from a stored procedure, you must explicitly set the
+     * length.
      * @return void
      */
-    public function bindParam($column, &$value, $type = 'string')
+    public function bindParam($column, &$value, $type = 'string', $length = null)
     {
         if ($type === null) {
             $type = 'string';
@@ -70,7 +74,7 @@ class MethodPDOStatement extends MethodStatementDecorator
         if (!ctype_digit((string)$type)) {
             list($value, $type) = $this->cast($value, $type);
         }
-        $this->_statement->bindParam($column, $value, $type);
+        $this->_statement->bindParam($column, $value, $type, $length);
     }
 
     /**

--- a/src/Database/Statement/Method/MethodStatementDecorator.php
+++ b/src/Database/Statement/Method/MethodStatementDecorator.php
@@ -55,11 +55,15 @@ class MethodStatementDecorator extends StatementDecorator implements StatementIn
      * @param string|int $column name or param position to be bound
      * @param mixed $value The value to bind to variable in query
      * @param string|int $type OCI type or name of configured Type class
+     * @param int $length [optional]
+     * Length of the data type. To indicate that a parameter is an OUT
+     * parameter from a stored procedure, you must explicitly set the
+     * length.
      * @return void
      */
-    public function bindParam($column, &$value, $type = 'string')
+    public function bindParam($column, &$value, $type = 'string', $length = null)
     {
-        $this->_statement->bindParam($column, $value, $type);
+        $this->_statement->bindParam($column, $value, $type, $length);
     }
 
 }

--- a/src/ORM/RequestTrait.php
+++ b/src/ORM/RequestTrait.php
@@ -413,7 +413,7 @@ trait RequestTrait
                     }
                 }
                 if ($parameter['out']) {
-                    $statement->bindParam($paramName, $this->_properties[$name], $type);
+                    $statement->bindParam($paramName, $this->_properties[$name], $type, $parameter['length']);
                 } else {
                     $statement->bindParam($paramName, $this->_castedProperties[$name], $type);
                 }

--- a/tests/CodeFixture/CalcCodeFixture.php
+++ b/tests/CodeFixture/CalcCodeFixture.php
@@ -29,6 +29,7 @@ class CalcCodeFixture extends MethodTestFixture
                 "create or replace package calc is
 
                 		function sum(a number, b number) return number;
+                		function twice(a in number, b out number) return varchar2;
 
                 end calc;";
             $this->create[] =
@@ -38,6 +39,12 @@ class CalcCodeFixture extends MethodTestFixture
                 	function sum(a number, b number) return number is
                       begin
                         return a+b;
+                      end;
+                    
+                      function twice(a in number, b out number) return varchar2 is
+                      begin
+                        b := a*2;
+                        return 'OK';
                       end;
 
                 end calc;";

--- a/tests/TestCase/ORM/MethodTest.php
+++ b/tests/TestCase/ORM/MethodTest.php
@@ -34,4 +34,16 @@ class MethodTest extends TestCase
         $this->assertEquals($request[':result'], 15);
         $this->assertEquals($request->result(), 15);
     }
+
+    public function testOutParameterMethodCall() {
+        $method = MethodRegistry::get('CalcTwice', ['method' => 'CALC.TWICE']);
+        $request = $method->newRequest(['A' => 5, 'B' => null]);
+        $this->assertTrue($request->isNew());
+        $this->assertTrue($method->execute($request));
+        $this->assertFalse($request->isNew());
+
+        $this->assertEquals($request->get('B'), 10);
+        $this->assertEquals($request[':result'], 'OK');
+        $this->assertEquals($request->result(), 'OK');
+    }
 }


### PR DESCRIPTION
I fixed #5 .
If you run test, you must create Oracle Package before run. (See #4 )

```
create or replace package calc is
  function sum(a number, b number) return number;
  function twice(a in number, b out number) return varchar2;
end calc;

create or replace package body calc is

  function sum(a number, b number) return number is
  begin
    return a+b;
  end;

  function twice(a in number, b out number) return varchar2 is
  begin
    b := a*2;
    return 'OK';
  end;

end calc;
```