### PR TITLE
Update OracleSchema.php

### DIFF
--- a/src/Database/Schema/OracleSchema.php
+++ b/src/Database/Schema/OracleSchema.php
@@ -612,10 +612,10 @@ WHERE 1=1 " . ($useOwner ? $ownerCondition : '') . $objectCondition . " ORDER BY
         $row = array_change_key_case($row);
         $data = [
             'type' => Table::CONSTRAINT_FOREIGN,
-            'columns' => strtolower($row['column_name']),
+            'columns' => strtoupper($row['column_name']),
             'references' => [
                 $row['referenced_owner'] . '.' . $row['referenced_table_name'],
-                strtolower($row['referenced_column_name'])
+                strtoupper($row['referenced_column_name'])
             ],
             'update' => Table::ACTION_SET_NULL,
             'delete' => $this->_convertOnClause($row['delete_rule']),


### PR DESCRIPTION
Table object has references to column names uppercase.  So we have to call addConstraint method with $data's columns names uppercase too. Otherwise the constraint column name doesn't match with the table column name.