### PR TITLE
Apply encoding to dsn

### DIFF
--- a/src/Database/Driver/OracleBase.php
+++ b/src/Database/Driver/OracleBase.php
@@ -114,7 +114,7 @@ abstract class OracleBase extends Driver
                 $pooled = '(SERVER=POOLED)';
             }
 
-            return '(DESCRIPTION=' . '(ADDRESS=(PROTOCOL=TCP)(HOST=' . $config['host'] . ')(PORT=' . $config['port'] . '))' . '(CONNECT_DATA=(' . $service . ')' . $instance . $pooled . '))';
+            return '(DESCRIPTION=' . '(ADDRESS=(PROTOCOL=TCP)(HOST=' . $config['host'] . ')(PORT=' . $config['port'] . '))' . '(CONNECT_DATA=(' . $service . ')' . $instance . $pooled . '));charset='.$config['encoding'];
 
         }
 


### PR DESCRIPTION
If you connect to the database, the charset given in the config is not applied to the dsn-string.