### PR TITLE
NUMBER without DATA_PRECISION as decimal

### DIFF
--- a/src/Database/Schema/OracleSchema.php
+++ b/src/Database/Schema/OracleSchema.php
@@ -192,7 +192,9 @@ WHERE 1=1 " . ($useOwner ? $ownerCondition : '') . $objectCondition . " ORDER BY
             case 'INTEGER':
             case 'PLS_INTEGER':
             case 'BINARY_INTEGER':
-                if ($row['data_precision'] == 1) {
+                if ($row['data_precision'] == null) {
+                    $field = ['type' => 'decimal', 'length' => $row['char_length']];
+                } elseif ($row['data_precision'] == 1) {
                     $field = [
                         'type' => 'boolean',
                         'length' => null


### PR DESCRIPTION
When NUMBER not have DATA_PRECISION then field is decimal:
https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1832
If a precision is not specified, the column stores values as given.

[Table 26-1](https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#g23242) shows examples of how data would be stored using different scale factors.