### PR TITLE
Use new version of TypeFactory::getMap()

### DIFF
--- a/src/ORM/Method/ResultSet.php
+++ b/src/ORM/Method/ResultSet.php
@@ -361,7 +361,7 @@ class ResultSet implements ResultSetInterface
     {
         $types = [];
         $schema = $this->_schema;
-        $map = array_keys(\Cake\Database\TypeFactory::map() + ['string' => 1, 'text' => 1, 'boolean' => 1]);
+        $map = array_keys(\Cake\Database\TypeFactory::getMap() + ['string' => 1, 'text' => 1, 'boolean' => 1]);
         $typeMap = array_combine(
             $map,
             array_map(['Cake\Database\Type', 'build'], $map)


### PR DESCRIPTION
`\Cake\Database\TypeFactor::map()` was replaced by `getMap()` in 4.0 (as far as I can tell from some archeology).

This was causing errors with Methods which I can reproduce if needed.